### PR TITLE
チャンネル名の不具合修正

### DIFF
--- a/front/src/app/features/tweetList/components/tweet/Tweet.css
+++ b/front/src/app/features/tweetList/components/tweet/Tweet.css
@@ -41,6 +41,7 @@
   max-width: 144px;
   height: 16px;
   margin: 6px 0;
+  overflow: hidden;
   font-size: var(--font-small-ex);
   font-weight: bold;
   line-height: 16px;


### PR DESCRIPTION
- チャンネル名が長いときは表示を途中で切る